### PR TITLE
Preserve Spindle speed set in G0 or G1, fixing #41

### DIFF
--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -1,0 +1,12 @@
+To build the program (with changes to the source):
+
+- install version 1.8 (aka 8.0) of the `JDK`, (openJDK variants such as [Azul's Zulu JDK](https://www.azul.com/downloads/?package=jdk&show-old-builds=true#zulu) may have better support for modern systems).
+
+- copy or hardlink `nrjavaserial-3.9.3.jar` and `jssc.jar` to the directory `./dist/lib/`
+
+- run `ant` from the top level directory of the repo to build the changes, with a command of the form 
+   ```
+     ant -Dplatforms.JDK_1.8.home=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home -Dnb.internal.action.name=build jar
+   ```
+
+this will produce the output jar files in the dist directory.

--- a/src/cnc/gcode/controller/CNCCommand.java
+++ b/src/cnc/gcode/controller/CNCCommand.java
@@ -85,13 +85,23 @@ public class CNCCommand {
         private final Type t;
         private final boolean xyz;
 
-        public Move(double[] s, double[] e, double a, Type t, boolean xyz) {
+        public Move(double[] s, double[] e, double a, Type t, boolean xyz, double spindle) {
             this.s = s;
             this.e = e;
             this.t = t;
             this.a = a;
             this.xyz=xyz;
+            this.spindle=spindle;
         }
+        
+        public Move(double[] s, double[] e, double a, Type t, boolean xyz) {
+           this.s = s;
+           this.e = e;
+           this.t = t;
+           this.a = a;
+           this.xyz=xyz;
+           this.spindle = Double.NaN;
+       }
         
         public void scalexy(double[] scale){
             for(int i=0;i<2;i++){
@@ -121,6 +131,10 @@ public class CNCCommand {
         public double getA(){
             return a;
         }
+        
+        public double getSpindle(){
+           return spindle;
+       }
         
         public double getDistanceXY()
         {
@@ -653,14 +667,17 @@ public class CNCCommand {
                     if(move.a!=0){
                         used=true;
                     }
+                    if(Double.isNaN(move.spindle) == false){
+                       message += "Spindle speed set";
+                       used=true;
+                   }
                     if(used == false)
                     {
                         if(state == State.NORMAL)
                         {
                             state = State.WARNING;
                         }
-                        message += "Command without any movment! Preserving anyway ";
-                        used = true;
+                        message += "Command without any movment!";
                     }
                     
                     if(move.s[2] != move.e[2] && Double.isNaN(move.e[2]) == false)
@@ -712,7 +729,11 @@ public class CNCCommand {
             case G1:
             case HOMING:
             case SETPOS:
-                moves.add(new Move(Arrays.copyOfRange(cin.axes, 0, 3), Arrays.copyOfRange(cout.axes, 0, 3),p.contains('A')?p.get('A').value:0.0, type,xyzmove));
+                if(p.contains('S')){
+                  moves.add(new Move(Arrays.copyOfRange(cin.axes, 0, 3), Arrays.copyOfRange(cout.axes, 0, 3),p.contains('A')?p.get('A').value:0.0, type,xyzmove, p.get('S').value));
+               } else {
+                  moves.add(new Move(Arrays.copyOfRange(cin.axes, 0, 3), Arrays.copyOfRange(cout.axes, 0, 3),p.contains('A')?p.get('A').value:0.0, type,xyzmove));
+               }
                 break;
 
             case ARC:
@@ -935,6 +956,12 @@ public class CNCCommand {
                         cmd += " " + 'A' + Tools.dtostr(move.a);                        
                         doMove = true;
                     }
+                    
+                    if(Double.isNaN(move.spindle)==false){
+                       cmd += " " + 'S' + Tools.dtostr(move.spindle);                        
+                       doMove = true;
+                   }
+                    
                     if(doMove == false && !Double.isNaN(cin.axes[3]) && !Double.isNaN(cout.axes[3]) && cin.axes[3] == cout.axes[3])
                     {
                         continue;

--- a/src/cnc/gcode/controller/CNCCommand.java
+++ b/src/cnc/gcode/controller/CNCCommand.java
@@ -81,6 +81,7 @@ public class CNCCommand {
         private final double[] s;
         private final double[] e;
         private double a;
+        private double spindle;
         private final Type t;
         private final boolean xyz;
 
@@ -658,7 +659,8 @@ public class CNCCommand {
                         {
                             state = State.WARNING;
                         }
-                        message += "Command without any movment! ";
+                        message += "Command without any movment! Preserving anyway ";
+                        used = true;
                     }
                     
                     if(move.s[2] != move.e[2] && Double.isNaN(move.e[2]) == false)


### PR DESCRIPTION
Fixes issue #41, no longer removing spindle speed when set in a command with no other motion.